### PR TITLE
Fixed the issue where multiple Order items couldn't be added to a new…

### DIFF
--- a/src/main/java/com/rokzasok/serveit/model/User.java
+++ b/src/main/java/com/rokzasok/serveit/model/User.java
@@ -56,7 +56,7 @@ public class User implements UserDetails {
 
     private Boolean enabled;
 
-    @ManyToMany(fetch = FetchType.EAGER)
+    @ManyToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
     @JoinTable(name = "user_role",
             joinColumns = @JoinColumn(name = "user_id", referencedColumnName = "id"),
             inverseJoinColumns = @JoinColumn(name = "role_id", referencedColumnName = "id"))


### PR DESCRIPTION
… Order because their IDs are all null -- java recognized them as the same object because their IDs were same; null. That has been fixed and orderDishes and orderDrinks can now have multiple items with null ID, which will get a non-null id upon saving.